### PR TITLE
Bug #169772 fix: Add Php 8 support

### DIFF
--- a/src/admin/tables/activity.php
+++ b/src/admin/tables/activity.php
@@ -65,6 +65,8 @@ class ActivityStreamTableActivity extends JTable
 			}
 		}
 
+		$errors = isset($errors) && is_array($errors) ? $errors : [];
+
 		if (count($errors))
 		{
 			$this->setError(implode($errors, ', '));

--- a/src/admin/tables/activity.php
+++ b/src/admin/tables/activity.php
@@ -69,7 +69,7 @@ class ActivityStreamTableActivity extends JTable
 
 		if (count($errors))
 		{
-			$this->setError(implode($errors, ', '));
+			$this->setError(implode(', ', $errors));
 
 			return false;
 		}

--- a/src/script.activitystream.php
+++ b/src/script.activitystream.php
@@ -231,7 +231,7 @@ class Com_ActivityStreamInstallerScript
 				{
 					$query = trim($query);
 
-					if ($query != '' && $query{0} != '#')
+					if ($query != '' && $query[0] != '#')
 					{
 						$db->setQuery($query);
 


### PR DESCRIPTION
Fatal error:
0 implode(): Argument #2 ($array) must be of type ?array, string given
/var/www/ttpllt-php8.local/public/sc/administrator/components/com_activitystream/tables/activity.php:72